### PR TITLE
Add statsd to docker prod configuration

### DIFF
--- a/config/prod.env
+++ b/config/prod.env
@@ -31,6 +31,8 @@ resource.rabbitmq.host=rabbitmq
 resource.rabbitmq.routing_key=collector.normal
 resource.rabbitmq.virtual_host=rabbitvhost
 
+resource.statsd.statsd_host=statsd
+
 # secret access key set up in fakes3 container
 secrets.boto.secret_access_key=whatever
 
@@ -39,17 +41,28 @@ secrets.rabbitmq.rabbitmq_user=rabbituser
 
 # save to s3, then notify on rabbitmq
 destination.crashstorage_class=collector.external.crashstorage_base.PolyCrashStorage
-destination.storage_classes=collector.external.boto.crashstorage.BotoS3CrashStorage, collector.external.rabbitmq.crashstorage.RabbitMQCrashStorage
+# Note: The actual values of this don't matter as long as the number is the same.
+destination.storage_classes=collector.external.boto.crashstorage.BotoS3CrashStorage,collector.external.rabbitmq.crashstorage.RabbitMQCrashStorage,collector.external.statsd.statsd_base.StatsdCounter
 
 # BotoS3CrashStorage
+destination.storage0.active_list=save_raw_crash
 destination.storage0.benchmark_tag=S3BenchmarkWrite
+destination.storage0.crashstorage_class=collector.external.statsd.statsd_base.StatsdBenchmarkingWrapper
 destination.storage0.filter_on_legacy_processing=True
-destination.storage0.crashstorage_class=collector.external.boto.crashstorage.BotoS3CrashStorage
+destination.storage0.statsd_prefix=crashmover.s3
+destination.storage0.wrapped_object_class=collector.external.boto.crashstorage.BotoS3CrashStorage
 
 # RabbitMQCrashStorage
 destination.storage1.benchmark_tag=S3BenchmarkWrite
 destination.storage1.crashstorage_class=collector.external.rabbitmq.crashstorage.RabbitMQCrashStorage
 destination.storage1.filter_on_legacy_processing=True
+destination.storage1.statsd_prefix=crashmover.rabbitmq
+destination.storage1.wrapped_object_class=collector.external.rabbitmq.crashstorage.RabbitMQCrashStorage
+
+# Statsd
+destination.storage2.active_list=save_raw_crash
+destination.storage2.crashstorage_class=collector.external.statsd.statsd_base.StatsdCounter
+destination.storage2.statsd_prefix=crashmover
 
 # FIXME: no clue if we need these
 producer_consumer.maximum_queue_size=24

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -28,8 +28,15 @@ services:
       - fakes3
     command: ./scripts/run_crashmover.sh
 
-  # FIXME: do statsd
-  # statsd:
+  statsd:
+    # https://hub.docker.com/r/hopsoft/graphite-statsd/
+    image: hopsoft/graphite-statsd
+    ports:
+      - "80:80"
+      - "2003-2004:2003-2004"
+      - "2023-2024:2023-2024"
+      - "8125:8125/udp"
+      - "8126:8126"
 
   rabbitmq:
     # https://hub.docker.com/_/rabbitmq/


### PR DESCRIPTION
This adds a statsd container and ties it into the crashmover for the
prod configuration simulating what we've got in production.

To see statsd data, go to http://localhost/ .

Fixes #21