### PR TITLE
Lint pass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ clean:
 	-rm .docker-build-prod
 
 lint:
-	${DOCKERCOMPOSE} run appbase flake8 collector
+	${DOCKERCOMPOSE} run appbase flake8 --statistics collector
 
 test:
 	${DOCKERCOMPOSE} run appbase ./scripts/test.sh

--- a/collector/app/fetch_transform_save_app.py
+++ b/collector/app/fetch_transform_save_app.py
@@ -33,11 +33,7 @@ from configman import Namespace
 from configman.converters import class_converter
 
 from collector.lib.task_manager import respond_to_SIGTERM
-from collector.app.generic_app import App, main  # main not used here, but
-                                               # is imported from generic_app
-                                               # into this scope to offer to
-                                               # apps that derive from the
-                                               # class defined here.
+from collector.app.generic_app import App
 
 
 #==============================================================================

--- a/collector/app/fetch_transform_save_app.py
+++ b/collector/app/fetch_transform_save_app.py
@@ -261,7 +261,7 @@ class FetchTransformSaveApp(App):
             # RabbitMQ, this is what removes the job from the queue.
             try:
                 finished_func()
-            except Exception, x:
+            except Exception as x:
                 # when run in a thread, a failure here is not a problem, but if
                 # we're running all in the same thread, a failure here could
                 # derail the the whole processor. Best just log the problem

--- a/collector/app/generic_app.py
+++ b/collector/app/generic_app.py
@@ -7,5 +7,5 @@ Socorro App class definitions.  That system has been moved to socorro_app.py.
 The following two imports into this module are for backwards compatibility.
 """
 
-from collector.app.socorro_app import main
-from collector.app.socorro_app import App
+from collector.app.socorro_app import main  # noqa
+from collector.app.socorro_app import App  # noqa

--- a/collector/crashmover_app.py
+++ b/collector/crashmover_app.py
@@ -123,7 +123,7 @@ class RawAndProcessedCopierApp(FetchTransformSaveWithSeparateNewCrashSourceApp):
                 'this crash cannot be found in raw crash storage'
             )
             return
-        except Exception, x:
+        except Exception as x:
             self.config.logger.warning(
                 'error loading crash %s',
                 crash_id,

--- a/collector/crashmover_app.py
+++ b/collector/crashmover_app.py
@@ -6,10 +6,10 @@
 
 from configman import Namespace
 
+from collector.app.generic_app import main
 from collector.app.fetch_transform_save_app import (
     FetchTransformSaveApp,
     FetchTransformSaveWithSeparateNewCrashSourceApp,
-    main
 )
 from collector.external.crashstorage_base import (
     CrashIDNotFound,

--- a/collector/database/transaction_executor.py
+++ b/collector/database/transaction_executor.py
@@ -45,7 +45,7 @@ class TransactionExecutor(RequiredConfig):
                 result = function(connection, *args, **kwargs)
                 connection.commit()
                 return result
-            except BaseException, x:
+            except BaseException as x:
                 connection.rollback()
                 if hasattr(x, 'abandon_transaction'):
                     self.config.logger.debug(
@@ -118,7 +118,7 @@ class TransactionExecutorWithInfiniteBackoff(TransactionExecutor):
                         connection.rollback()
                         raise
 
-            except self.db_conn_context_source.conditional_exceptions, x:
+            except self.db_conn_context_source.conditional_exceptions as x:
                 # these exceptions may or may not be retriable
                 # the test is for is a last ditch effort to see if
                 # we can retry
@@ -140,7 +140,7 @@ class TransactionExecutorWithInfiniteBackoff(TransactionExecutor):
                     self.connection_source_type,
                     exc_info=True)
 
-            except BaseException, x:
+            except BaseException as x:
                 if hasattr(x, 'abandon_transaction'):
                     self.config.logger.debug(
                         '%s transaction intentionally abandoned by exception',

--- a/collector/external/boto/crashstorage.py
+++ b/collector/external/boto/crashstorage.py
@@ -171,7 +171,7 @@ class BotoCrashStorage(CrashStorageBase):
                 "raw_crash"
             )
             return json.loads(raw_crash_as_string, object_hook=DotDict)
-        except boto_connection.ResponseError, x:
+        except boto_connection.ResponseError as x:
             raise CrashIDNotFound(
                 '%s not found: %s' % (crash_id, x)
             )
@@ -188,7 +188,7 @@ class BotoCrashStorage(CrashStorageBase):
                 name = 'dump'
             a_dump = boto_connection.fetch(crash_id, name)
             return a_dump
-        except boto_connection.ResponseError, x:
+        except boto_connection.ResponseError as x:
             raise CrashIDNotFound(
                 '%s not found: %s' % (crash_id, x)
             )
@@ -219,7 +219,7 @@ class BotoCrashStorage(CrashStorageBase):
                     dump_name
                 )
             return dumps
-        except boto_connection.ResponseError, x:
+        except boto_connection.ResponseError as x:
             raise CrashIDNotFound(
                 '%s not found: %s' % (crash_id, x)
             )
@@ -251,7 +251,7 @@ class BotoCrashStorage(CrashStorageBase):
                 processed_crash_as_string,
                 object_hook=DotDict
             )
-        except boto_connection.ResponseError, x:
+        except boto_connection.ResponseError as x:
             raise CrashIDNotFound(
                 '%s not found: %s' % (crash_id, x)
             )

--- a/collector/external/crashstorage_base.py
+++ b/collector/external/crashstorage_base.py
@@ -540,7 +540,7 @@ class PolyCrashStorage(CrashStorageBase):
         for a_store in self.stores.itervalues():
             try:
                 a_store.close()
-            except Exception, x:
+            except Exception as x:
                 self.logger.error('%s failure: %s', a_store.__class__,
                                   str(x))
                 storage_exception.gather_current_exception()
@@ -579,7 +579,7 @@ class PolyCrashStorage(CrashStorageBase):
             self.quit_check()
             try:
                 a_store.save_processed(processed_crash)
-            except Exception, x:
+            except Exception as x:
                 self.logger.error('%s failure: %s', a_store.__class__,
                                   str(x), exc_info=True)
                 storage_exception.gather_current_exception()

--- a/collector/external/fs/crashstorage.py
+++ b/collector/external/fs/crashstorage.py
@@ -31,7 +31,7 @@ from collector.lib.util import DotDict
 def dates_to_strings_for_json(obj):
     if isinstance(obj, datetime.datetime):
         return obj.isoformat()
-    return json.JSONEncoder.default(self, obj)
+    raise TypeError('obj not JSON encodable')
 
 
 @contextmanager
@@ -725,13 +725,6 @@ class TarFileSequentialReadingCrashStore(CrashStorageBase):
         default='gzip',
         from_string_converter=class_converter
     )
-
-    #------------------------------------------------------------------------------
-    @staticmethod
-    def stringify_datetimes(obj):
-        if isinstance(obj, datetime.date):
-            return obj.iso_format()
-        return json.JSONEncoder.default(self, obj)
 
     #------------------------------------------------------------------------------
     def _create_tarfile(self):

--- a/collector/external/fs/filesystem.py
+++ b/collector/external/fs/filesystem.py
@@ -31,7 +31,7 @@ def cleanEmptySubdirectories(topLimit, leafPath, osModule=os):
             break
         try:
             osModule.rmdir(opath)
-        except OSError, e:
+        except OSError as e:
             if errno.ENOTEMPTY == e.errno:
                 break
             else:
@@ -92,7 +92,7 @@ def makedirs(name, mode=0777, osModule=os):
             return
     try:
         osModule.mkdir(name, mode)
-    except OSError, e:
+    except OSError as e:
         #be happy if someone already created the path
         if e.errno != errno.EEXIST:
             raise

--- a/collector/external/fs/filesystem.py
+++ b/collector/external/fs/filesystem.py
@@ -20,7 +20,7 @@ def cleanEmptySubdirectories(topLimit, leafPath, osModule=os):
     opath = os.path.normpath(leafPath)  # allows relative paths to work
     topLimit = os.path.split(os.path.normpath(topLimit))[1]  # allows name or
                                                              # path
-    if not topLimit in opath:
+    if topLimit not in opath:
         raise OSError(
           errno.ENOENT,
           '%s not on path to %s' % (topLimit, leafPath)

--- a/collector/external/fs/fs_new_crash_source.py
+++ b/collector/external/fs/fs_new_crash_source.py
@@ -5,8 +5,6 @@
 from configman import Namespace, RequiredConfig
 from configman.converters import class_converter
 
-from functools import partial
-
 
 #==============================================================================
 class FSNewCrashSource(RequiredConfig):

--- a/collector/external/rabbitmq/crashstorage.py
+++ b/collector/external/rabbitmq/crashstorage.py
@@ -170,7 +170,7 @@ class RabbitMQCrashStorage(CrashStorageBase):
         # queues the crash_id. The '_consume_acknowledgement_queue' function
         # is run to send acknowledgments back to RabbitMQ
         self._consume_acknowledgement_queue()
-        conn = self.rabbitmq.connection()
+        self.rabbitmq.connection()
         queues = [
             self.rabbitmq.config.priority_queue_name,
             self.rabbitmq.config.standard_queue_name,

--- a/collector/external/statsd/crashstorage.py
+++ b/collector/external/statsd/crashstorage.py
@@ -2,11 +2,5 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-
-from collector.external.statsd.statsd_base import (
-    StatsdCounter as StatsdCrashStorage,
-)
-from collector.external.statsd.statsd_base import (
-    StatsdBenchmarkingWrapper as StatsdBenchmarkingCrashStorage,
-)
-
+from collector.external.statsd.statsd_base import StatsdCounter as StatsdCrashStorage  # noqa
+from collector.external.statsd.statsd_base import StatsdBenchmarkingWrapper as StatsdBenchmarkingCrashStorage  # noqa

--- a/collector/external/statsd/statsd_rule_benchmark.py
+++ b/collector/external/statsd/statsd_rule_benchmark.py
@@ -2,9 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from collector.external.statsd.statsd_base import (
-    StatsdBenchmarkingWrapper as StatsdRuleBenchmarkWrapper,
-)
+from collector.external.statsd.statsd_base import StatsdBenchmarkingWrapper as StatsdRuleBenchmarkWrapper  # noqa
 
 # How is this class used?
 #

--- a/collector/lib/ooid.py
+++ b/collector/lib/ooid.py
@@ -56,7 +56,8 @@ def dateAndDepthFromOoid(ooid):
   try:
     year = 2000 + int(ooid[-6:-4])
     depth = int(ooid[-7])
-    if not depth: depth = oldHardDepth
+    if not depth:
+      depth = oldHardDepth
     return (dt.datetime(year,month,day,tzinfo=UTC),depth)
   except:
     return None,None

--- a/collector/lib/task_manager.py
+++ b/collector/lib/task_manager.py
@@ -3,7 +3,6 @@ import threading
 import os
 
 from configman import RequiredConfig, Namespace
-from configman.converters import class_converter
 
 #------------------------------------------------------------------------------
 def default_task_func(a_param):

--- a/collector/lib/threaded_task_manager.py
+++ b/collector/lib/threaded_task_manager.py
@@ -7,7 +7,7 @@ import time
 import threading
 import Queue
 
-from configman import RequiredConfig, Namespace
+from configman import Namespace
 from configman.converters import class_converter
 
 from collector.lib.task_manager import (

--- a/collector/lib/transform_rules.py
+++ b/collector/lib/transform_rules.py
@@ -63,7 +63,7 @@ class Rule(RequiredConfig):
         """
         try:
             return self._predicate(*args, **kwargs)
-        except Exception, x:
+        except Exception as x:
             self.config.logger.debug(
                 'Rule %s predicicate failed because of "%s"',
                 to_str(self.__class__),
@@ -93,13 +93,13 @@ class Rule(RequiredConfig):
         classification system itself."""
         try:
             return self._action(*args, **kwargs)
-        except KeyError, x:
+        except KeyError as x:
             self.config.logger.debug(
                 'Rule %s action failed because of missing key "%s"',
                 to_str(self.__class__),
                 x,
             )
-        except Exception, x:
+        except Exception as x:
             self.config.logger.debug(
                 'Rule %s action failed because of "%s"',
                 to_str(self.__class__),
@@ -326,7 +326,7 @@ class TransformRuleSystem(RequiredConfig):
                     self.rules.append(
                         a_rule_class(config[ns_name])
                     )
-                except KeyError, x:
+                except KeyError as x:
                     self.rules.append(
                         a_rule_class(config)
                     )

--- a/collector/lib/transform_rules.py
+++ b/collector/lib/transform_rules.py
@@ -326,7 +326,7 @@ class TransformRuleSystem(RequiredConfig):
                     self.rules.append(
                         a_rule_class(config[ns_name])
                     )
-                except KeyError as x:
+                except KeyError:
                     self.rules.append(
                         a_rule_class(config)
                     )

--- a/collector/lib/util.py
+++ b/collector/lib/util.py
@@ -4,8 +4,6 @@
 
 import sys
 import traceback
-import datetime
-import cStringIO
 import threading
 import collections
 

--- a/collector/lib/util.py
+++ b/collector/lib/util.py
@@ -28,24 +28,36 @@ class FakeLogger(object):
     return '%s %s' % (loggingLevelString, message)
   def log(self,*x,**kwargs):
     print >>sys.stderr, self.createLogMessage(*x)
-  def debug(self,*x,**kwargs): self.log(logging.DEBUG, *x)
-  def info(self,*x,**kwargs): self.log(logging.INFO, *x)
-  def warning(self,*x,**kwargs): self.log(logging.WARNING, *x)
+  def debug(self,*x,**kwargs):
+    self.log(logging.DEBUG, *x)
+  def info(self,*x,**kwargs):
+    self.log(logging.INFO, *x)
+  def warning(self,*x,**kwargs):
+    self.log(logging.WARNING, *x)
   warn = warning
-  def error(self,*x,**kwargs): self.log(logging.ERROR, *x)
-  def critical(self,*x,**kwargs): self.log(logging.CRITICAL, *x)
+  def error(self,*x,**kwargs):
+    self.log(logging.ERROR, *x)
+  def critical(self,*x,**kwargs):
+    self.log(logging.CRITICAL, *x)
   fatal = critical
 
 
 #=================================================================================================================
 class SilentFakeLogger(object):
-  def log(self,*x,**kwargs): pass
-  def debug(self,*x,**kwargs): pass
-  def info(self,*x,**kwargs): pass
-  def warning(self,*x,**kwargs): pass
-  def error(self,*x,**kwargs): pass
-  def critical(self,*x,**kwargs): pass
-  def fatal(self,*x,**kwargs):pass
+  def log(self,*x,**kwargs):
+    pass
+  def debug(self,*x,**kwargs):
+    pass
+  def info(self,*x,**kwargs):
+    pass
+  def warning(self,*x,**kwargs):
+    pass
+  def error(self,*x,**kwargs):
+    pass
+  def critical(self,*x,**kwargs):
+    pass
+  def fatal(self,*x,**kwargs):
+    pass
 
 #=================================================================================================================
 class StringLogger(FakeLogger):

--- a/collector/lib/util.py
+++ b/collector/lib/util.py
@@ -107,7 +107,7 @@ def reportExceptionAndContinue(logger=FakeLogger(), loggingLevel=logging.ERROR, 
           logger.log(loggingLevel, aLine.strip())
     finally:
       loggingReportLock.release()
-  except Exception, x:
+  except Exception as x:
     print >>sys.stderr, x
 
 #-----------------------------------------------------------------------------------------------------------------

--- a/collector/lib/ver_tools.py
+++ b/collector/lib/ver_tools.py
@@ -128,7 +128,7 @@ def normalize(version_string, max_version_parts=4):
     for part_count, version_part in enumerate(version_string.split('.')):
         try:
             groups = _version_part_re.match(version_part).groups()
-        except Exception as x:
+        except Exception:
             raise NotAVersionException(version_string)
         version_list.extend(t(x) for x, t in zip(groups, _normalize_fn_list))
     version_list.extend(_padding_list * (max_version_parts - part_count - 1))

--- a/collector/lib/ver_tools.py
+++ b/collector/lib/ver_tools.py
@@ -77,7 +77,7 @@ _padding_list = [0, _padding_high_string, 0, _padding_high_string]
 # low, while missing strings are to sort high.
 def _str_to_int(x):
     """given a string, this function converts to an int"""
-    if x == None or x == '':
+    if x is None or x == '':
         return 0
     return int(x)
 
@@ -85,7 +85,7 @@ def _str_to_high_str(x):
     """given a string, this funtion converts the special values '' and None
     to the special value 'zzzzzz'.  This is used to insure empty values have
     a high sort order"""
-    if x == None or x == '':
+    if x is None or x == '':
         return _padding_high_string
     return x
 

--- a/collector/lib/ver_tools.py
+++ b/collector/lib/ver_tools.py
@@ -128,7 +128,7 @@ def normalize(version_string, max_version_parts=4):
     for part_count, version_part in enumerate(version_string.split('.')):
         try:
             groups = _version_part_re.match(version_part).groups()
-        except Exception, x:
+        except Exception as x:
             raise NotAVersionException(version_string)
         version_list.extend(t(x) for x, t in zip(groups, _normalize_fn_list))
     version_list.extend(_padding_list * (max_version_parts - part_count - 1))

--- a/collector/throttler.py
+++ b/collector/throttler.py
@@ -227,7 +227,7 @@ class LegacyThrottler(RequiredConfig):
                 else:
                     throttle_match = condition(raw_crash[key])
             except KeyError:
-                if key == None:
+                if key is None:
                     throttle_match = condition(None)
                 else:
                     #this key is not present in the jsonData - skip

--- a/collector/unittest/__init__.py
+++ b/collector/unittest/__init__.py
@@ -1,4 +1,3 @@
-from nose.tools import ok_
 from collector.unittest.skip_if import skip_if
 
 __all__ = ['skip_if']

--- a/collector/unittest/app/test_for_application_defaults.py
+++ b/collector/unittest/app/test_for_application_defaults.py
@@ -4,7 +4,6 @@
 
 from nose.tools import eq_, ok_
 
-from configman import class_converter
 from configman.dotdict import DotDict
 
 from collector.unittest.testbase import TestCase

--- a/collector/unittest/app/test_socorro_app.py
+++ b/collector/unittest/app/test_socorro_app.py
@@ -3,7 +3,6 @@ from nose.tools import eq_, ok_, assert_raises
 from collector.unittest.testbase import TestCase
 
 from configman import (
-    class_converter,
     Namespace,
     command_line,
     ConfigFileFutureProxy,
@@ -12,9 +11,7 @@ from configman.dotdict import DotDict
 
 from collector.app.socorro_app import (
     SocorroApp,
-    SocorroWelcomeApp,
     main,
-    klass_to_pypath,
 )
 from collector.app.for_application_defaults import ApplicationDefaultsProxy
 

--- a/collector/unittest/app/test_socorro_app.py
+++ b/collector/unittest/app/test_socorro_app.py
@@ -76,10 +76,9 @@ class TestSocorroApp(TestCase):
 
     #--------------------------------------------------------------------------
     def test_do_run(self):
-        config = DotDict()
         with mock.patch('collector.app.socorro_app.ConfigurationManager') as cm:
             cm.return_value.context.return_value = mock.MagicMock()
-            with mock.patch('collector.app.socorro_app.signal') as s:
+            with mock.patch('collector.app.socorro_app.signal'):
                 class SomeOtherApp(SocorroApp):
                     app_name='SomeOtherApp'
                     app_verision='1.2.3'
@@ -112,10 +111,9 @@ class TestSocorroApp(TestCase):
 
     #--------------------------------------------------------------------------
     def test_do_run_with_alternate_class_path(self):
-        config = DotDict()
         with mock.patch('collector.app.socorro_app.ConfigurationManager') as cm:
             cm.return_value.context.return_value = mock.MagicMock()
-            with mock.patch('collector.app.socorro_app.signal') as s:
+            with mock.patch('collector.app.socorro_app.signal'):
                 class SomeOtherApp(SocorroApp):
                     app_name='SomeOtherApp'
                     app_verision='1.2.3'
@@ -150,10 +148,9 @@ class TestSocorroApp(TestCase):
 
     #--------------------------------------------------------------------------
     def test_do_run_with_alternate_values_source_list(self):
-        config = DotDict()
         with mock.patch('collector.app.socorro_app.ConfigurationManager') as cm:
             cm.return_value.context.return_value = mock.MagicMock()
-            with mock.patch('collector.app.socorro_app.signal') as s:
+            with mock.patch('collector.app.socorro_app.signal'):
                 class SomeOtherApp(SocorroApp):
                     app_name='SomeOtherApp'
                     app_verision='1.2.3'

--- a/collector/unittest/database/test_transaction_executor.py
+++ b/collector/unittest/database/test_transaction_executor.py
@@ -16,9 +16,12 @@ from collector.unittest.testbase import TestCase
 # From psycopg2.
 TRANSACTION_STATUS_IDLE = 0
 TRANSACTION_STATUS_INTRANS = 2
-class OperationalError(Exception): pass
-class ProgrammingError(Exception): pass
-class InterfaceError(Exception): pass
+class OperationalError(Exception):
+    pass
+class ProgrammingError(Exception):
+    pass
+class InterfaceError(Exception):
+    pass
 
 
 class SomeError(Exception):

--- a/collector/unittest/external/boto/test_connection_context.py
+++ b/collector/unittest/external/boto/test_connection_context.py
@@ -382,7 +382,7 @@ class MultiplePathsTestCase(MultiplePathsBase):
         )
         mocked_get_contents_as_string.side_effect = [thing_as_str]
 
-        result = connection_source.fetch(
+        connection_source.fetch(
             'fff13cf0-5671-4496-ab89-47a922141114',
             'raw_crash'
         )

--- a/collector/unittest/external/fs/test_fs_new_crash_source.py
+++ b/collector/unittest/external/fs/test_fs_new_crash_source.py
@@ -32,7 +32,7 @@ class TestConnection(TestCase):
 
     #--------------------------------------------------------------------------
     def _setup_config(self):
-        config = DotDict();
+        config = DotDict()
         config.crashstorage_class = FakeCrashStore
         return config
 

--- a/collector/unittest/external/rabbitmq/test_connection_context.py
+++ b/collector/unittest/external/rabbitmq/test_connection_context.py
@@ -68,7 +68,7 @@ class TestConnectionContext(TestCase):
 
     #--------------------------------------------------------------------------
     def _setup_config(self):
-        config = DotDict();
+        config = DotDict()
         config.host = 'localhost'
         config.virtual_host = '/'
         config.port = '5672'
@@ -141,7 +141,7 @@ class TestConnectionContextPooled(TestCase):
 
     #--------------------------------------------------------------------------
     def _setup_config(self):
-        config = DotDict();
+        config = DotDict()
         config.host = 'localhost'
         config.virtual_host = '/'
         config.port = '5672'

--- a/collector/unittest/external/rabbitmq/test_connection_context.py
+++ b/collector/unittest/external/rabbitmq/test_connection_context.py
@@ -46,8 +46,7 @@ class TestConnection(TestCase):
             call(queue='socorro.reprocessing', durable=True),
         ]
         eq_(
-            faked_connection_object.channel.return_value.queue_declare \
-                .call_args_list,
+            faked_connection_object.channel.return_value.queue_declare.call_args_list,
             expected_queue_declare_call_args
         )
 
@@ -98,14 +97,12 @@ class TestConnectionContext(TestCase):
         with patch(pika_string) as mocked_pika_module:
             conn_context_functor = ConnectionContext(config)
             conn = conn_context_functor.connection()
-            mocked_pika_module.credentials.PlainCredentials \
-                .assert_called_once_with('guest', 'guest')
+            mocked_pika_module.credentials.PlainCredentials.assert_called_once_with('guest', 'guest')
             mocked_pika_module.ConnectionParameters.assert_called_once_with(
                 host=conn_context_functor.config.host,
                 port=conn_context_functor.config.port,
                 virtual_host=conn_context_functor.config.virtual_host,
-                credentials=mocked_pika_module.credentials. \
-                    PlainCredentials.return_value
+                credentials=mocked_pika_module.credentials.PlainCredentials.return_value
             )
             mocked_pika_module.BlockingConnection.assert_called_one_with(
                 mocked_pika_module.ConnectionParameters.return_value

--- a/collector/unittest/external/rabbitmq/test_priorityjobs.py
+++ b/collector/unittest/external/rabbitmq/test_priorityjobs.py
@@ -70,8 +70,8 @@ class IntegrationTestPriorityjobs(TestCase):
             assert_raises(priorityjobs.MissingArgumentError,
                               jobs.create)
             ok_(
-                mocked_connection.return_value.channel. \
-                    basic_publish.called_once_with(
+                mocked_connection.return_value.channel
+                    .basic_publish.called_once_with(
                         '',
                         'socorro.priority',
                         'b1',

--- a/collector/unittest/external/rabbitmq/test_rmq_new_crash_source.py
+++ b/collector/unittest/external/rabbitmq/test_rmq_new_crash_source.py
@@ -32,7 +32,7 @@ class TestConnection(TestCase):
 
     #--------------------------------------------------------------------------
     def _setup_config(self):
-        config = DotDict();
+        config = DotDict()
         config.crashstorage_class = FakeCrashStore
         return config
 

--- a/collector/unittest/external/statsd/test_crashstorage.py
+++ b/collector/unittest/external/statsd/test_crashstorage.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from mock import patch, call, Mock
-from nose.tools import eq_, ok_, assert_raises
+from nose.tools import eq_
 from collector.unittest.testbase import TestCase
 
 from datetime import datetime

--- a/collector/unittest/external/statsd/test_stastsd_rule_benchmark.py
+++ b/collector/unittest/external/statsd/test_stastsd_rule_benchmark.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from mock import patch, call, Mock
-from nose.tools import eq_, ok_, assert_raises
+from nose.tools import ok_, assert_raises
 from collector.unittest.testbase import TestCase
 
 from datetime import datetime
@@ -16,7 +16,6 @@ from collector.external.statsd.statsd_rule_benchmark import (
     CountStackWalkerTimeoutKills,
     CountStackWalkerFailures,
 )
-from collector.external.statsd.statsd_base import StatsdCounter
 from collector.unittest.lib.test_transform_rules import (
     TestRuleTestLaughable,
     TestRuleTestDangerous

--- a/collector/unittest/external/statsd/test_stastsd_rule_benchmark.py
+++ b/collector/unittest/external/statsd/test_stastsd_rule_benchmark.py
@@ -6,8 +6,6 @@ from mock import patch, call, Mock
 from nose.tools import ok_, assert_raises
 from collector.unittest.testbase import TestCase
 
-from datetime import datetime
-
 from configman.dotdict import DotDict
 
 from collector.external.statsd.statsd_rule_benchmark import (
@@ -78,13 +76,7 @@ class TestStatsdCounterRule(TestCase):
         ok_(isinstance(trs.rules[1].wrapped_object, TestRuleTestDangerous))
 
         now_str = 'collector.external.statsd.statsd_base.datetime'
-        with patch(now_str) as now_mock:
-            times =  [
-                datetime(2015, 5, 4, 15, 10, 3),
-                datetime(2015, 5, 4, 15, 10, 2),
-                datetime(2015, 5, 4, 15, 10, 1),
-                datetime(2015, 5, 4, 15, 10, 0),
-            ]
+        with patch(now_str):
             ok_(trs.rules[0].predicate(None))
             statsd_obj.timing.has_calls([])
             ok_(trs.rules[1].action(None))

--- a/collector/unittest/external/test_crashstorage_base.py
+++ b/collector/unittest/external/test_crashstorage_base.py
@@ -149,7 +149,7 @@ class TestBase(TestCase):
             except AttributeError:
                 p.gather_current_exception()
             raise p
-        except PolyStorageError, x:
+        except PolyStorageError as x:
             eq_(len(x), 3)
             ok_(x.has_exceptions())
             types = [NameError, KeyError, AttributeError]

--- a/collector/unittest/lib/testOoid.py
+++ b/collector/unittest/lib/testOoid.py
@@ -95,6 +95,3 @@ class TestOoid(TestCase):
       assert self.baseDate == date, 'Expect %s, got %s' %(self.baseDate, date)
     assert oo.dateAndDepthFromOoid(self.badooid0) == (None, None)
     assert oo.dateAndDepthFromOoid(self.badooid1) == (None, None)
-
-if __name__ == "__main__":
-  unittest.main()

--- a/collector/unittest/lib/testOoid.py
+++ b/collector/unittest/lib/testOoid.py
@@ -58,8 +58,8 @@ class TestOoid(TestCase):
       assert self.xmas05 == ndate1, 'Expect date of %s, got %s' %(self.xmas05,ndate1)
       assert ndepth0 == ndepth1, 'Expect depth0(%d) == depth1(%d)' %(ndepth0,ndepth1)
       assert d == ndepth0, 'Expect depth %d, got %d' % (d,ndepth0)
-    assert None == oo.depthFromOoid(self.badooid0)
-    assert None == oo.depthFromOoid(self.badooid1)
+    assert oo.depthFromOoid(self.badooid0) is None
+    assert oo.depthFromOoid(self.badooid1) is None
 
   def testUuidToOid(self):
     for i in range(len(self.rawuuids)):
@@ -85,16 +85,16 @@ class TestOoid(TestCase):
     for ooid in self.yyyyoids:
       assert self.baseDate == oo.dateFromOoid(ooid), 'Expected %s got %s' %(self.baseDate, oo.dateFromOoid(ooid))
       assert 4 == oo.depthFromOoid(ooid), 'Expected %d, got %d' %(4, oo.depthFromOoid(ooid))
-    assert None == oo.dateFromOoid(self.badooid0)
-    assert None == oo.dateFromOoid(self.badooid1)
+    assert oo.dateFromOoid(self.badooid0) is None
+    assert oo.dateFromOoid(self.badooid1) is None
 
   def testGetDateAndDepth(self):
     for i in range(len(self.dyyoids)):
       date,depth = oo.dateAndDepthFromOoid(self.dyyoids[i])
       assert self.depths[i] == depth, 'Expect depth=%d, got %d (%s)'%(self.depth[i],depth,self.dyyoids[i])
       assert self.baseDate == date, 'Expect %s, got %s' %(self.baseDate, date)
-    assert (None,None) == oo.dateAndDepthFromOoid(self.badooid0)
-    assert (None,None) == oo.dateAndDepthFromOoid(self.badooid1)
+    assert oo.dateAndDepthFromOoid(self.badooid0) == (None, None)
+    assert oo.dateAndDepthFromOoid(self.badooid1) == (None, None)
 
 if __name__ == "__main__":
   unittest.main()

--- a/collector/unittest/lib/test_task_manager.py
+++ b/collector/unittest/lib/test_task_manager.py
@@ -25,7 +25,7 @@ class TestTaskManager(TestCase):
         ok_(tm.config == config)
         ok_(tm.logger == self.logger)
         ok_(tm.task_func == default_task_func)
-        ok_(tm.quit == False)
+        ok_(tm.quit is False)
 
     def test_executor_identity(self):
         config = DotDict()

--- a/collector/unittest/lib/test_threaded_task_manager.py
+++ b/collector/unittest/lib/test_threaded_task_manager.py
@@ -32,7 +32,7 @@ class TestThreadedTaskManager(TestCase):
             ok_(ttm.config == config)
             ok_(ttm.logger == self.logger)
             ok_(ttm.task_func == default_task_func)
-            ok_(ttm.quit == False)
+            ok_(ttm.quit is False)
         finally:
             # we got threads to join
             ttm._kill_worker_threads()
@@ -53,7 +53,7 @@ class TestThreadedTaskManager(TestCase):
             ok_(ttm.thread_list[0].isAlive(),
                             "the worker thread is stillborn")
             ttm.stop()
-            ok_(ttm.queuing_thread.isAlive() == False,
+            ok_(ttm.queuing_thread.isAlive() is False,
                             "the queuing thread did not stop")
         except Exception:
             # we got threads to join

--- a/collector/unittest/lib/test_transform_rules.py
+++ b/collector/unittest/lib/test_transform_rules.py
@@ -69,7 +69,7 @@ class TestRuleTestNoCloseMethod(transform_rules.Rule):
 class TestRuleTestBrokenCloseMethod(transform_rules.Rule):
 
     def _action(self, *args, **kwargs):
-        return true
+        return True
 
     def close(self):
         # this is deliberately breaking

--- a/collector/unittest/test_crash_mover_app.py
+++ b/collector/unittest/test_crash_mover_app.py
@@ -79,7 +79,7 @@ class TestCrashMoverApp(TestCase):
                                      })
                 self.number_of_close_calls = 0
 
-            def close():
+            def close(self):
                 self.number_of_close_calls += 1
 
             def get_raw_crash(self, ooid):
@@ -92,10 +92,6 @@ class TestCrashMoverApp(TestCase):
             def new_crashes(self):
                 for k in self.store.keys():
                     yield k
-
-            def close(self):
-                self.number_of_close_calls += 1
-                pass
 
         class FakeStorageDestination(object):
 

--- a/collector/unittest/test_wsgi_generic_collector.py
+++ b/collector/unittest/test_wsgi_generic_collector.py
@@ -2,10 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import hashlib
 import StringIO
 import gzip
-import web
 
 import mock
 from nose.tools import eq_, ok_

--- a/collector/unittest/webapi/test_class_partial.py
+++ b/collector/unittest/webapi/test_class_partial.py
@@ -25,7 +25,7 @@ class TestPartialForServiceClasses(TestCase):
                 eq_(local_config, config)
 
         wrapped_class = class_with_partial_init(A, local_config)
-        a = wrapped_class()
+        wrapped_class()
         eq_(wrapped_class.global_config, None)
 
 
@@ -40,7 +40,7 @@ class TestPartialForServiceClasses(TestCase):
                 eq_(local_config, config)
 
         wrapped_class = class_with_partial_init(A, local_config, global_config)
-        a = wrapped_class()
+        wrapped_class()
         eq_(wrapped_class.global_config, global_config)
 
     #--------------------------------------------------------------------------

--- a/collector/unittest/webapi/test_class_partial.py
+++ b/collector/unittest/webapi/test_class_partial.py
@@ -2,9 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from mock import Mock, patch
-from nose.tools import eq_, ok_
-from contextlib import contextmanager
+from nose.tools import eq_
 
 from configman.dotdict import DotDict, DotDictWithAcquisition
 

--- a/collector/wsgi_generic_collector.py
+++ b/collector/wsgi_generic_collector.py
@@ -12,7 +12,6 @@ from contextlib import closing
 
 from collector.lib.ooid import createNewOoid
 from collector.lib.util import DotDict
-from collector.throttler import DISCARD, IGNORE
 from collector.lib.datetimeutil import utc_now
 from collector.external.crashstorage_base import MemoryDumpsMapping
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,15 @@
+[flake8]
+# E1: ignore all indentation issues
+# E2: ignore all whitespace issues
+# E3: ignore all blank line issues
+# E402: ignore module level import not at top of file issues
+# E501: ignore line too long issues
+# W293: ignore blank line contains whitespace issues
+# W391: ignore blank line at end of file issues
+# W503: ignore line break before binary operator issues
+ignore = E1,E2,E3,E402,E501,W293,W391,W503
+exclude = docs
+
 [bumpversion]
 current_version = 0.1.0
 commit = True
@@ -9,10 +21,6 @@ tag = True
 
 [wheel]
 universal = 1
-
-[flake8]
-ignore = E501
-exclude = docs
 
 [pytest]
 addopts=-rsxX --tb=native


### PR DESCRIPTION
This fixes the linting infrastructure to narrow the focus of what we're linting to things that aren't pep8-y.

Then it fixes the remaining lint issues. Each commit fixes a specific issue. Going through the commits one-by-one is probably fine. Doing them all at once is probably fine, too.

Most of the changes are trivial. A couple of them were slightly more involved. The bulk of them were in the unit tests.

To test, I ran `make lint`, `make test` and also sent a test crash report through the system using the dev and prod configurations. Pretty sure that should cover all the bases.